### PR TITLE
Fixed ironsights not working

### DIFF
--- a/mp/src/game/client/in_main.cpp
+++ b/mp/src/game/client/in_main.cpp
@@ -1627,6 +1627,10 @@ static ConCommand startgrenade2( "+grenade2", IN_Grenade2Down );
 static ConCommand startattack3("+attack3", IN_Attack3Down);
 static ConCommand endattack3("-attack3", IN_Attack3Up);
 
+// KORNEEL - Mild RnL stuff, just so we don't have to rename commands in configs (also makes more sense with this name)
+static ConCommand startironsights("+ironsights", IN_ZoomDown);
+static ConCommand endironsights("-ironsights", IN_ZoomUp);
+
 #ifdef TF_CLIENT_DLL
 static ConCommand toggle_duck( "toggle_duck", IN_DuckToggle );
 #endif


### PR DESCRIPTION
Ironsights are bound to +/-ironsights in config. Rather than use +/-zoom (which is a little confusing) I opted to keep the original bounds. 
The issue is that CInput is not a class which is easily extendible. Practically overriding functions is non-trivial and it uses static functions. 

- I tried to extend `GetButtonBits(..)`, but the order of adding to the bits flag matters, so we cannot do it at the completely beginning (resets to 0), or at the end (does other flag operations)
- I also tried to add a new function call which we can inherit from after all the `CalcButtonBits(..)` calls in `GetButtonBits(..)`, but it's static, and we cannot just include entire in_main.cpp...

So, this is the solution. Do you have any thoughts on how okay it is to modify source-sdk code, vs inheriting and overriding? I think it's fair to say we don't expect further engine updates, but still..