### PR TITLE
Improved Ironsights not predicting properly

### DIFF
--- a/mp/src/game/client/in_main.cpp
+++ b/mp/src/game/client/in_main.cpp
@@ -139,7 +139,7 @@ static	kbutton_t	in_alt1;
 static	kbutton_t	in_alt2;
 static	kbutton_t	in_score;
 static	kbutton_t	in_break;
-static	kbutton_t	in_zoom;
+kbutton_t	in_zoom;
 static  kbutton_t   in_grenade1;
 static  kbutton_t   in_grenade2;
 static	kbutton_t	in_attack3;


### PR DESCRIPTION
Tested with :

- cl_rnl_weapon_pred_once  0 and 1
- net_fakelag 200+

It was very jittery before and would jump around in animations, or initiate too late after the client started the action.
Making the input not a static seems to improve things a lot...  I wonder if that will improve the reload too..